### PR TITLE
fix: make CasInSEnstiVe

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ const run = async() => {
     properties: {
       username: {
         default: username,
-        pattern: /^[a-z0-9_-]{3,15}$/,
+        pattern: /^[A-Za-z0-9_-]{3,15}$/,
         message: 'Name must be only letters, numbers, underscores, or dashes',
       },
     },


### PR DESCRIPTION
**Goal**
- Update to allow capital letters in github username

![github_username_error](https://cloud.githubusercontent.com/assets/15616532/24839938/5e2055f4-1d31-11e7-8ad5-e2d249f70a1e.PNG)

just thought I would throw this out there as I had this issue running this on Windows.